### PR TITLE
Add SwissTopo map example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # weatherviz
 
+This repository contains a simple frontend example that displays a SwissTopo base map centered over Switzerland. The map uses the grey basemap so that weather layers can be added later without visual distraction.
+
+Open `index.html` in a web browser to see the map.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Swiss Weather Map</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+zKUFF8GPKMq4xGz+3wS3ehJ0S6j52/Voh3EeMG3o=" crossorigin="" />
+    <style>
+        body, html { margin: 0; padding: 0; height: 100%; }
+        #map { width: 100%; height: 100%; }
+    </style>
+</head>
+<body>
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-QVYau9NHkeO3cPT2a+XSS72EygGyE1fQWx121lX0JZQ=" crossorigin=""></script>
+    <script>
+      const map = L.map('map').setView([46.8182, 8.2275], 8);
+      L.tileLayer('https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-grau/default/current/3857/{z}/{x}/{y}.jpeg', {
+        attribution: 'Map data &copy; <a href="https://www.swisstopo.admin.ch/">swisstopo</a>',
+        maxZoom: 18,
+        minZoom: 5,
+        crossOrigin: true
+      }).addTo(map);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple Leaflet-based example to show a SwissTopo grey basemap
- document how to launch the frontend

## Testing
- `curl -I https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-grau/default/current/3857/0/0/0.jpeg`

------
https://chatgpt.com/codex/tasks/task_e_686ad4bb780c83258659a9b4634739b4