### PR TITLE
Add meteodata-lab based STAC conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 This is a private, experimental project aimed at visualizing MeteoSwiss open weather model data. The viewer uses Leaflet to display these data on top of SwissTopo maps by default, while allowing alternative background layers to be selected.
 
-The code is written in Python and includes a server-side component to convert data into a web-friendly format for the map interface.
+The project now includes a lightweight backend script that uses the
+`meteodata-lab` library to download forecast fields from the MeteoSwiss STAC
+catalog and convert them into simple PNG images for display in the Leaflet
+frontend.
+
+## Usage
+
+1. Install the Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Convert a forecast field to PNG:
+   ```bash
+   python backend/stac_converter.py \
+       ch.meteoschweiz.ogd-forecasting-icon-ch2 T \
+       --ref-time latest --horizon P0DT0H \
+       output.png
+   ```
+   Adjust the collection ID, variable, reference time and horizon as needed.
+   The script retrieves the data via `meteodata-lab`, rescales it to 8‑bit and
+   writes `output.png`.
 
 Open `index.html` in a web browser to see the map.

--- a/backend/stac_converter.py
+++ b/backend/stac_converter.py
@@ -1,0 +1,98 @@
+"""Utilities to download MeteoSwiss STAC data and save it as PNG."""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+from meteodatalab import ogd_api
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def fetch_variable(
+    collection: str,
+    variable: str,
+    ref_time: str,
+    horizon: str,
+    perturbed: bool,
+) -> "xarray.DataArray":
+    """Retrieve a forecast field as an ``xarray.DataArray``."""
+
+    request = ogd_api.Request(
+        collection=ogd_api.Collection(collection),
+        variable=variable,
+        reference_datetime=ref_time,
+        perturbed=perturbed,
+        horizon=horizon,
+    )
+    return ogd_api.get_from_ogd(request)
+
+
+def array_to_png(data: np.ndarray, output_path: Path) -> None:
+    """Save a 2D NumPy array as an 8-bit grayscale PNG."""
+
+    logger.info("Saving PNG to %s", output_path)
+    data_min = np.nanmin(data)
+    data_max = np.nanmax(data)
+    if data_max == data_min:
+        scaled = np.zeros_like(data, dtype=np.uint8)
+    else:
+        scaled = 255 * (data - data_min) / (data_max - data_min)
+    img = Image.fromarray(scaled.astype(np.uint8))
+    img.save(output_path)
+
+
+def variable_to_png(
+    collection: str,
+    variable: str,
+    ref_time: str,
+    horizon: str,
+    perturbed: bool,
+    output_path: str,
+) -> None:
+    """Download a forecast field and save it as a PNG image."""
+
+    da = fetch_variable(collection, variable, ref_time, horizon, perturbed)
+    array_to_png(da.values.squeeze(), Path(output_path))
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Download an OGD forecast variable and save it as a PNG"
+    )
+    parser.add_argument(
+        "collection",
+        help="STAC collection ID, e.g. ch.meteoschweiz.ogd-forecasting-icon-ch2",
+    )
+    parser.add_argument("variable", help="Variable short name, e.g. T or U_10M")
+    parser.add_argument(
+        "--ref-time",
+        default="latest",
+        help="Reference time (default: latest)",
+    )
+    parser.add_argument(
+        "--horizon",
+        default="P0DT0H",
+        help="Forecast horizon as ISO-8601 duration",
+    )
+    parser.add_argument(
+        "--perturbed",
+        action="store_true",
+        help="Retrieve ensemble member instead of deterministic field",
+    )
+    parser.add_argument("output", help="Output PNG path")
+    args = parser.parse_args()
+
+    variable_to_png(
+        args.collection,
+        args.variable,
+        args.ref_time,
+        args.horizon,
+        args.perturbed,
+        args.output,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+meteodata-lab
+pillow


### PR DESCRIPTION
## Summary
- refine `stac_converter.py` to use the `meteodata-lab` library
- simplify dependencies to `meteodata-lab` and `pillow`
- document new usage of the backend script

## Testing
- `pip check`
- `python backend/stac_converter.py --help`


------
https://chatgpt.com/codex/tasks/task_e_686ae2380cb8832592b5c3e70fd8717d